### PR TITLE
Исправление глобальной переменной irbis_event_loop

### DIFF
--- a/docs/chapter2.rst
+++ b/docs/chapter2.rst
@@ -537,6 +537,6 @@ workstation   str   Тип АРМа (см. таблицу ниже)   'C'
 
   irbis.init_async()
 
-  irbis.irbis_event_loop.run_until_complete(do_async_stuff())
+  irbis.get_event_loop().run_until_complete(do_async_stuff())
 
   irbis.close_async()

--- a/irbis/__init__.py
+++ b/irbis/__init__.py
@@ -10,7 +10,7 @@
 # IRBIS64 supported: 2014 and higher
 
 from irbis._common import ADMINISTRATOR, BRIEF, CATALOGER, close_async, \
-    init_async, irbis_event_loop, LAST, LOCKED, LOGICALLY_DELETED, \
+    init_async, get_event_loop, LAST, LOCKED, LOGICALLY_DELETED, \
     NON_ACTUALIZED, NOT_CONNECTED, PHYSICALLY_DELETED, prepare_format, \
     remove_comments
 

--- a/irbis/_common.py
+++ b/irbis/_common.py
@@ -395,8 +395,21 @@ def init_async() -> None:
     """
     global irbis_event_loop  # pylint: disable=global-statement
     if not irbis_event_loop:
-        irbis_event_loop = asyncio.get_event_loop()
+        try:
+            irbis_event_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            print("New event loop")
+            irbis_event_loop = asyncio.new_event_loop()
+            print(irbis_event_loop)
 
+def get_event_loop() -> None | asyncio.AbstractEventLoop:
+    """
+    Получение асинхронного цикла сообщений.
+
+    :return None | asyncio.AbstractEventLoop
+    """
+    global irbis_event_loop
+    return irbis_event_loop
 
 def close_async() -> None:
     """

--- a/irbis/_common.py
+++ b/irbis/_common.py
@@ -398,9 +398,7 @@ def init_async() -> None:
         try:
             irbis_event_loop = asyncio.get_running_loop()
         except RuntimeError:
-            print("New event loop")
             irbis_event_loop = asyncio.new_event_loop()
-            print(irbis_event_loop)
 
 def get_event_loop() -> None | asyncio.AbstractEventLoop:
     """

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as fh:
 
 setuptools.setup(
     name="irbis",
-    version="0.2",
+    version="0.2.1",
     author="Alexey Mironov",
     author_email="amironov73@gmail.com",
     description="Framework for client development for popular Prussian library computer system IRBIS64",


### PR DESCRIPTION
Добавил функцию ```get_event_loop()``` которая возвращает irbis_event_loop. У меня нет возможности проверить работу на реальном сервере, поэтому проверку на подключение и взаимодействие не могу выполнить.
Не могу проверить поэтому отдельный пул реквест что бы не попало в релиз раньше времени.